### PR TITLE
Handle situation where no hashtags or handles are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ The app does the following when you visit it:
 1. Grabs the data from [a designated Google Spreadsheet](https://docs.google.com/spreadsheets/d/1-p0CyUMC0nqrEQNc6Yikd2vg033GoChSWR8rFKFxfgU/edit#gid=1209202081)*.
 2. Loops through rows, checking the date column* until it finds one in
    the future. (Default: `date`)
-3. On finding a future event, grabs the content of a specific column*.
+3. On finding a future event, grabs the stub content from a specific column*.
    (Default: `presenter_social_media`)
+4. If no #hashtags or @handles found in that stub content, uses the
+   `default_tweet` config*.
 4. Redirects browser to a page that will auto-initiate a Tweet with that
    content.
 
-\* <sup>configurable</sup>
+\* <sup>[configurable](#Configuration)</sup>
 
 Note: We have an intermediary button-click involved so that mobile apps
 open the web intent properly, rather than getting stuck redirecting to Twitter's web

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ fork_me_url: https://github.com/civictechto/tweet-stub-helper
 app_name: Hacknight Tweet Helper
 org_name: Civic Tech Toronto
 org_url: http://civictech.ca
+default_tweet: "@CivicTechTO #civictech #toronto"
 gsheet:
   key: 1-p0CyUMC0nqrEQNc6Yikd2vg033GoChSWR8rFKFxfgU
   sheet_id: 1209202081

--- a/index.js
+++ b/index.js
@@ -45,7 +45,10 @@ const routes = [
             }
           }
           const contentHeader = '{{ site.gsheet.content_header }}'
-          const tweetStubContent = currentEvent[contentHeader]
+          var tweetStubContent = currentEvent[contentHeader]
+          if (!/\B(?:\#|\@)[a-zA-Z_]+\b/.test(tweetStubContent)) {
+            tweetStubContent = '{{ site.default_tweet }}'
+          }
           const redirectUrl = 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(tweetStubContent)
           window.location.replace(redirectUrl)
         },


### PR DESCRIPTION
Slack context: https://civictechto.slack.com/archives/C4SHX39B2/p1558752153003000

Marica brought up that the tweet helper can be confusing. It's intended to pull hashtags and twitter handles from the speaker booking spreadsheet, but sometimes these are missing, or it says "To be announced." (This is because the same spreadsheet cell is used to generate the meetup event section that shares the hashtags.)

We could instead change the little tweet helper app to do this:
1. Detect is the spreadsheet field is empty or filled with regular text (`To be announced`) instead of something like `#sometag @somehandle @someotherhandle`
2. If it is missing tweetable information, then either:
    - disable the tweet button and say "no social media tags provided this week" ([example](https://user-images.githubusercontent.com/305339/58424854-6752a600-8066-11e9-8c84-3c2970846245.png)), or
    - fall back to a general set of handles and hashtags, like `@CivicTechTO #civictech`.